### PR TITLE
add launcher configs for vs code

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,21 @@
+{
+	// Use IntelliSense to learn about possible attributes.
+	// Hover to view descriptions of existing attributes.
+	// For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+	"version": "0.2.0",
+	"configurations": [
+		{
+			"type": "chrome",
+			"request": "launch",
+			"name": "Launch Chrome",
+			"url": "http://localhost:3000",
+			"webRoot": "${workspaceFolder}/client"
+		},
+		{
+			"type": "node",
+			"request": "launch",
+			"name": "Launch Server",
+			"program": "${workspaceFolder}/server/src/index.js"
+		}
+	]
+}


### PR DESCRIPTION
I was unable to figure out how to create a launcher to start the react server, but I added one to launch chrome to `http://localhost:3000` and one to launch the websocket server.